### PR TITLE
Fix TargetDepartureTime order

### DIFF
--- a/custom_components/ovapi/sensor.py
+++ b/custom_components/ovapi/sensor.py
@@ -232,6 +232,7 @@ class OvApiSensor(Entity):
                     "line_name": stop['TransportType'].title() + ' ' + stop['LinePublicNumber'] + ' - ' +
                                  stop['DestinationName50'],
                     "stop_name": stop['TimingPointName'],
+                    "TargetDepartureDateTime": target_departure_time,
                     "TargetDepartureTime": target_departure_time.time(),
                     "ExpectedArrivalTime": expected_arrival_time.time(),
                     "Delay": delay
@@ -251,7 +252,7 @@ class OvApiSensor(Entity):
                 self._departures = STATE_UNKNOWN
                 self._state = STATE_UNKNOWN
             else:
-                stops_list.sort(key=operator.itemgetter('TargetDepartureTime'))
+                stops_list.sort(key=operator.itemgetter('TargetDepartureDateTime'))
 
                 self._destination = stops_list[self._sensor_number]["destination"]
                 self._provider = stops_list[self._sensor_number]["provider"]


### PR DESCRIPTION
Departure times were only sorted by time, not date time. So 00:15 would show before 23:15.